### PR TITLE
Agregue un marcador y renderice el mapa

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,7 @@ import { HttpClient } from '@angular/common/http';
 //import { Product } from './models/product.model';
 import { Message } from './models/message.model';
 import { NgOptimizedImage } from '@angular/common';
-import { Map, tileLayer } from 'leaflet';
+import { Map, marker, tileLayer } from 'leaflet';
 
 @Component({
   selector: 'app-root',
@@ -20,6 +20,12 @@ export class AppComponent {
       maxZoom: 19,
       attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
     }).addTo(map);
+
+    const markerItem = marker([-17.44326, -66.11255]).addTo(map).bindPopup("Mi casa");
+    map.fitBounds([
+      [markerItem.getLatLng().lat, markerItem.getLatLng().lng]
+    ]);
+
   }
 
   http = inject(HttpClient);


### PR DESCRIPTION
## Cambios Realizados
- Agregué la capacidad de agregar un marcador en una ubicación específica mediante coordenadas de latitud y longitud.
- Implementé un popunder que muestra la información "Mi casa" cuando se hace clic en el marcador.
- Realicé ajustes en la configuración del mapa para que se centre automáticamente en esta ubicación al cargarse.

## Contexto Adicional
Esta adición agrega una capa adicional de funcionalidad a la aplicación al permitir que los usuarios marquen y vean ubicaciones específicas en el mapa. También hace que la aplicación sea más intuitiva y fácil de usar al centrarse automáticamente en la ubicación marcada.
